### PR TITLE
Let users decide whether to open DAP REPL automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Also the corresponding Lua functions with the same names as the arguments are av
 | `g:cmake_asyncrun_options`        | `{'save': 2}`                           | AsyncRun [options](https://github.com/skywind3000/asyncrun.vim#manual) that will be passed on cmake execution.                                                                                                                 |
 | `g:cmake_target_asyncrun_options` | `{}`                                    | AsyncRun [options](https://github.com/skywind3000/asyncrun.vim#manual) that will be passed on target execution.                                                                                                                |
 | `g:cmake_dap_configuration`       | `{'type': 'cpp', 'request': 'launch'}`  | Default DAP configuration that works with `lldb-vscode`                                                                                                                                                                        |
+| `g:cmake_dap_repl_open`           | `v:true`                                | Set this value to `v:false` to stop DAP REPL from opening automatically                                                                                                                                                        |
 
 The user may also specify the default path to run the targets from by defining it in the `g:cmake_parameters_file` in the base directory of the project, (i.e):
 

--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -86,7 +86,9 @@ function cmake.debug(...)
     config = vim.tbl_extend('force', config, vim.g.cmake_dap_configuration)
   end
   dap.run(config)
-  dap.repl.open()
+  if vim.g.cmake_dap_repl_open then
+    dap.repl.open()
+  end
 end
 
 function cmake.clean(...)

--- a/plugin/cmake.vim
+++ b/plugin/cmake.vim
@@ -12,6 +12,7 @@ let g:cmake_build_arguments = get(g:, 'cmake_build_arguments', '')
 let g:cmake_asyncrun_options = get(g:, 'cmake_asyncrun_options', {'save': 2})
 let g:cmake_target_asyncrun_options = get(g:, 'cmake_target_asyncrun_options', {})
 let g:cmake_dap_configuration  = get(g:, 'cmake_dap_configuration', {'type': 'cpp', 'request': 'launch'})
+let g:cmake_dap_repl_open  = get(g:, 'cmake_dap_repl_open', v:true)
 
 function! s:match_commands(arg, line, pos)
   return luaeval('require("cmake.commands").match_commands("' .. a:arg .. '")')


### PR DESCRIPTION
The plugin opens DAP REPL automatically, this PR lets users decide whether to open DAP REPL automatically.