### PR TITLE
Display program output quickfix_only_on_error = true

### DIFF
--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -69,7 +69,7 @@ function cmake.run(...)
   end
 
   vim.list_extend(args, { ... })
-  return utils.run(target.filename, args, { cwd = target_dir.filename })
+  return utils.run(target.filename, args, { cwd = target_dir.filename, quickfix_only_on_error = false })
 end
 
 function cmake.debug(...)

--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -69,7 +69,7 @@ function cmake.run(...)
   end
 
   vim.list_extend(args, { ... })
-  return utils.run(target.filename, args, { cwd = target_dir.filename, quickfix_only_on_error = false })
+  return utils.run(target.filename, args, { cwd = target_dir.filename, open_quickfix = true })
 end
 
 function cmake.debug(...)

--- a/lua/cmake/utils.lua
+++ b/lua/cmake/utils.lua
@@ -42,8 +42,8 @@ end
 
 function utils.run(cmd, args, opts)
   vim.fn.setqflist({}, ' ', { title = cmd .. ' ' .. table.concat(args, ' ') })
-  opts.quickfix_only_on_error = vim.F.if_nil(opts.quickfix_only_on_error, config.quickfix_only_on_error)
-  if not opts.quickfix_only_on_error then
+  opts.open_quickfix = vim.F.if_nil(opts.open_quickfix, not config.quickfix_only_on_error)
+  if opts.open_quickfix then
     show_quickfix()
   end
 
@@ -59,7 +59,7 @@ function utils.run(cmd, args, opts)
         if opts.on_success then
           opts.on_success()
         end
-      elseif opts.quickfix_only_on_error then
+      elseif config.quickfix_only_on_error then
         show_quickfix()
         vim.api.nvim_command('cbottom')
       end

--- a/lua/cmake/utils.lua
+++ b/lua/cmake/utils.lua
@@ -42,7 +42,8 @@ end
 
 function utils.run(cmd, args, opts)
   vim.fn.setqflist({}, ' ', { title = cmd .. ' ' .. table.concat(args, ' ') })
-  if not config.quickfix_only_on_error then
+  opts.quickfix_only_on_error = vim.F.if_nil(opts.quickfix_only_on_error, config.quickfix_only_on_error)
+  if not opts.quickfix_only_on_error then
     show_quickfix()
   end
 
@@ -58,7 +59,7 @@ function utils.run(cmd, args, opts)
         if opts.on_success then
           opts.on_success()
         end
-      elseif config.quickfix_only_on_error then
+      elseif opts.quickfix_only_on_error then
         show_quickfix()
         vim.api.nvim_command('cbottom')
       end

--- a/lua/cmake/utils.lua
+++ b/lua/cmake/utils.lua
@@ -59,7 +59,7 @@ function utils.run(cmd, args, opts)
         if opts.on_success then
           opts.on_success()
         end
-      elseif config.quickfix_only_on_error then
+      elseif not opts.show_quickfix then
         show_quickfix()
         vim.api.nvim_command('cbottom')
       end


### PR DESCRIPTION
Small fix for https://github.com/Shatur/neovim-cmake/pull/26, setting `config.quickfix_only_on_error` to `true` is causing the calls for `run` and `build_and_run` to not show the program output

This PR fixes it by adding a new property `quickfix_only_on_error` to opts of `utils.run` and make it fallback to `config.quickfix_only_on_error` if it's passed to the function and make `cmake.run` set it to `false`