### PR TITLE
Fix argument order for CMake build command

### DIFF
--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -44,8 +44,7 @@ function cmake.build(args)
     return
   end
 
-  args = args or {}
-  vim.list_extend(args, { '--build', project_config:get_build_dir().filename, '--target', project_config.json.current_target, unpack(config.build_args) })
+  args = vim.list_extend({ '--build', project_config:get_build_dir().filename, '--target', project_config.json.current_target, unpack(config.build_args) }, args or {})
   return utils.run(config.cmake_executable, args, { on_success = project_config:copy_compile_commands() })
 end
 
@@ -55,8 +54,7 @@ function cmake.build_all(args)
   end
 
   local project_config = ProjectConfig.new()
-  args = args or {}
-  vim.list_extend(args, { '--build', project_config:get_build_dir().filename })
+  args = vim.list_extend({ '--build', project_config:get_build_dir().filename }, args or {})
   return utils.run(config.cmake_executable, args, { on_success = project_config:copy_compile_commands() })
 end
 
@@ -113,8 +111,7 @@ function cmake.clean(args)
   end
 
   local project_config = ProjectConfig.new()
-  args = args or {}
-  vim.list_extend(args, { '--build', project_config:get_build_dir().filename, '--target', 'clean' })
+  args = vim.list_extend({ '--build', project_config:get_build_dir().filename, '--target', 'clean' }, args or {})
   return utils.run(config.cmake_executable, args, { on_success = project_config:copy_compile_commands() })
 end
 


### PR DESCRIPTION
It looks like in a recent cmake version (I have 3.23.1) the order of arguments for the --build comand is now important.

Building with `cmake --parallel --build -b someDir --target someTarget` will always fail because `--parallel` has to be placed after `--build`.

I am not familiar with lua but I tested the change and it seems to work, I just reversed the order of the concatination.