### PR TITLE
fix recursive copying in utils.copy_folder

### DIFF
--- a/lua/cmake/utils.lua
+++ b/lua/cmake/utils.lua
@@ -35,7 +35,7 @@ function utils.copy_folder(folder, destination)
         error('Unable to copy ' .. target_entry)
       end
     else
-      utils.copy_folder(folder, target_entry)
+      utils.copy_folder(source_entry, target_entry)
     end
   end
 end


### PR DESCRIPTION
If a project template contains sub-directories, 'CMake create_project' throws a 'FileNotFoundError' error. This fixes it.