### PR TITLE
Add possibility to set build_dir from a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ local Path = require('plenary.path')
 require('cmake').setup({
   cmake_executable = 'cmake', -- CMake executable to run.
   parameters_file = 'neovim.json', -- JSON file to store information about selected target, run arguments and build type.
-  build_dir = tostring(Path:new('{cwd}', 'build', '{os}-{build_type}')), -- Build directory. The expressions `{cwd}`, `{os}` and `{build_type}` will be expanded with the corresponding text values.
+  build_dir = tostring(Path:new('{cwd}', 'build', '{os}-{build_type}')), -- Build directory. The expressions `{cwd}`, `{os}` and `{build_type}` will be expanded with the corresponding text values. Could be a function that return the path to the build directory.
   samples_path = tostring(script_path:parent():parent():parent() / 'samples'), -- Folder with samples. `samples` folder from the plugin directory is used by default.
   default_projects_path = tostring(Path:new(vim.loop.os_homedir(), 'Projects')), -- Default folder for creating project.
   configure_args = { '-D', 'CMAKE_EXPORT_COMPILE_COMMANDS=1' }, -- Default arguments that will be always passed at cmake configure step. By default tells cmake to generate `compile_commands.json`.

--- a/lua/cmake/project_config.lua
+++ b/lua/cmake/project_config.lua
@@ -48,7 +48,10 @@ function ProjectConfig:get_build_dir()
   if self.build_dir then
     return self.build_dir
   end
-
+  if vim.is_callable(config.build_dir) then
+    self.build_dir = Path:new(config.build_dir())
+    return self.build_dir
+  end
   self.build_dir = config.build_dir
   self.build_dir = self.build_dir:gsub('{cwd}', vim.loop.cwd())
   self.build_dir = self.build_dir:gsub('{os}', os)


### PR DESCRIPTION
I work with a pretty big codebase which consists of multiple CMake packages (sometimes 300 :D), so having a fixed string for the build_dir doesn't work well for my case, it would be great to have an option to call a function similar to [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#clangd)'s root_dir
