### PR TITLE
Add config parameter to disable copying compile commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ require('cmake').setup({
   on_build_output = nil, -- Callback which will be called on every line that is printed during build process. Accepts printed line as argument.
   quickfix_height = 10, -- Height of the opened quickfix.
   quickfix_only_on_error = false, -- Open quickfix window only if target build failed.
+  copy_compile_commands = true, -- Copy compile_commands.json to current working directory.
   dap_configuration = { type = 'cpp', request = 'launch' }, -- DAP configuration. By default configured to work with `lldb-vscode`.
   dap_open_command = require('dap').repl.open, -- Command to run after starting DAP session. You can set it to `false` if you don't want to open anything or `require('dapui').open` if you are using https://github.com/rcarriga/nvim-dap-ui
 })

--- a/lua/cmake/config.lua
+++ b/lua/cmake/config.lua
@@ -13,6 +13,7 @@ local config = {
     on_build_output = nil,
     quickfix_height = 10,
     quickfix_only_on_error = false,
+    copy_compile_commands = true,
     dap_configuration = { type = 'cpp', request = 'launch' },
     dap_open_command = require('dap').repl.open,
   },

--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -30,7 +30,7 @@ function cmake.configure(args)
 
   args = args or {}
   vim.list_extend(args, { '-B', project_config:get_build_dir().filename, '-D', 'CMAKE_BUILD_TYPE=' .. project_config.json.build_type, unpack(config.configure_args) })
-  return utils.run(config.cmake_executable, args, { on_success = project_config:copy_compile_commands() })
+  return utils.run(config.cmake_executable, args, { on_success = config.copy_compile_commands and project_config:copy_compile_commands() })
 end
 
 function cmake.build(args)
@@ -45,7 +45,7 @@ function cmake.build(args)
   end
 
   args = vim.list_extend({ '--build', project_config:get_build_dir().filename, '--target', project_config.json.current_target, unpack(config.build_args) }, args or {})
-  return utils.run(config.cmake_executable, args, { on_success = project_config:copy_compile_commands() })
+  return utils.run(config.cmake_executable, args, { on_success = config.copy_compile_commands and project_config:copy_compile_commands() })
 end
 
 function cmake.build_all(args)
@@ -55,7 +55,7 @@ function cmake.build_all(args)
 
   local project_config = ProjectConfig.new()
   args = vim.list_extend({ '--build', project_config:get_build_dir().filename, unpack(config.build_args) }, args or {})
-  return utils.run(config.cmake_executable, args, { on_success = project_config:copy_compile_commands() })
+  return utils.run(config.cmake_executable, args, { on_success = config.copy_compile_commands and project_config:copy_compile_commands() })
 end
 
 function cmake.run(args)
@@ -112,7 +112,7 @@ function cmake.clean(args)
 
   local project_config = ProjectConfig.new()
   args = vim.list_extend({ '--build', project_config:get_build_dir().filename, '--target', 'clean' }, args or {})
-  return utils.run(config.cmake_executable, args, { on_success = project_config:copy_compile_commands() })
+  return utils.run(config.cmake_executable, args, { on_success = config.copy_compile_commands and project_config:copy_compile_commands() })
 end
 
 function cmake.build_and_run(args)


### PR DESCRIPTION
Sometimes this file could be big so it would be great to have an option to disable copying it
