### PR TITLE
Fixed pack and unpack functions

### DIFF
--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -19,7 +19,7 @@ function cmake.configure(...)
   end
 
   local args = vim.list_extend({ '-B', project_config:get_build_dir().filename, '-D', 'CMAKE_BUILD_TYPE=' .. project_config.json.build_type }, config.configure_args)
-  vim.list_extend(args, table.pack(...))
+  vim.list_extend(args, {...})
   return utils.run(config.cmake_executable, args, { copy_compile_commands_from = project_config:get_build_dir() })
 end
 
@@ -31,14 +31,14 @@ function cmake.build(...)
   end
 
   local args = vim.list_extend({ '--build', project_config:get_build_dir().filename, '--target', project_config.json.current_target }, config.build_args)
-  vim.list_extend(args, table.pack(...))
+  vim.list_extend(args, {...})
   return utils.run(config.cmake_executable, args, { copy_compile_commands_from = project_config:get_build_dir() })
 end
 
 function cmake.build_all(...)
   local project_config = ProjectConfig.new()
   local args = vim.list_extend({ '--build', project_config:get_build_dir().filename }, config.build_args)
-  vim.list_extend(args, table.pack(...))
+  vim.list_extend(args, {...})
   return utils.run(config.cmake_executable, args, { copy_compile_commands_from = project_config:get_build_dir() })
 end
 
@@ -49,7 +49,7 @@ function cmake.run(...)
     return
   end
 
-  vim.list_extend(target_args, table.pack(...))
+  vim.list_extend(target_args, {...})
   return utils.run(target.filename, target_args, { cwd = target_dir.filename, force_quickfix = true })
 end
 
@@ -68,7 +68,7 @@ function cmake.debug(...)
     return
   end
 
-  vim.list_extend(target_args, table.pack(...))
+  vim.list_extend(target_args, {...})
 
   local dap_config = {
     name = project_config.json.current_target,
@@ -85,7 +85,7 @@ end
 
 function cmake.clean(...)
   local project_config = ProjectConfig.new()
-  local args = vim.list_extend({ '--build', project_config:get_build_dir().filename, '--target', 'clean' }, table.pack(...))
+  local args = vim.list_extend({ '--build', project_config:get_build_dir().filename, '--target', 'clean' }, {...})
   return utils.run(config.cmake_executable, args, { copy_compile_commands_from = project_config:get_build_dir() })
 end
 

--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -19,7 +19,7 @@ function cmake.configure(...)
   end
 
   local args = vim.list_extend({ '-B', project_config:get_build_dir().filename, '-D', 'CMAKE_BUILD_TYPE=' .. project_config.json.build_type }, config.configure_args)
-  vim.list_extend(args, {...})
+  vim.list_extend(args, { ... })
   return utils.run(config.cmake_executable, args, { copy_compile_commands_from = project_config:get_build_dir() })
 end
 
@@ -31,14 +31,14 @@ function cmake.build(...)
   end
 
   local args = vim.list_extend({ '--build', project_config:get_build_dir().filename, '--target', project_config.json.current_target }, config.build_args)
-  vim.list_extend(args, {...})
+  vim.list_extend(args, { ... })
   return utils.run(config.cmake_executable, args, { copy_compile_commands_from = project_config:get_build_dir() })
 end
 
 function cmake.build_all(...)
   local project_config = ProjectConfig.new()
   local args = vim.list_extend({ '--build', project_config:get_build_dir().filename }, config.build_args)
-  vim.list_extend(args, {...})
+  vim.list_extend(args, { ... })
   return utils.run(config.cmake_executable, args, { copy_compile_commands_from = project_config:get_build_dir() })
 end
 
@@ -49,7 +49,7 @@ function cmake.run(...)
     return
   end
 
-  vim.list_extend(target_args, {...})
+  vim.list_extend(target_args, { ... })
   return utils.run(target.filename, target_args, { cwd = target_dir.filename, force_quickfix = true })
 end
 
@@ -68,7 +68,7 @@ function cmake.debug(...)
     return
   end
 
-  vim.list_extend(target_args, {...})
+  vim.list_extend(target_args, { ... })
 
   local dap_config = {
     name = project_config.json.current_target,
@@ -85,7 +85,7 @@ end
 
 function cmake.clean(...)
   local project_config = ProjectConfig.new()
-  local args = vim.list_extend({ '--build', project_config:get_build_dir().filename, '--target', 'clean' }, {...})
+  local args = vim.list_extend({ '--build', project_config:get_build_dir().filename, '--target', 'clean' }, { ... })
   return utils.run(config.cmake_executable, args, { copy_compile_commands_from = project_config:get_build_dir() })
 end
 

--- a/lua/cmake/subcommands.lua
+++ b/lua/cmake/subcommands.lua
@@ -40,7 +40,7 @@ function subcommands.run(subcommand)
     utils.notify('Subcommand: ' .. subcommand.fargs[1] .. ' should have ' .. subcommand_info.nparams .. ' argument(s)', vim.log.levels.ERROR)
     return
   end
-  subcommand_func(table.unpack(subcommand.fargs, 2))
+  subcommand_func(unpack(subcommand.fargs, 2))
 end
 
 return subcommands


### PR DESCRIPTION
table.pack and table.unpack functions are not supported by LuaJIT 2.1.0-beta3 and it's advised to change `table.pack(...)` to `{...}` and `table.unpack` to `unpack`