### PR TITLE
Add support for default json parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ require('cmake').setup({
   cmake_executable = 'cmake', -- CMake executable to run.
   save_before_build = true, -- Save all buffers before building.
   parameters_file = 'neovim.json', -- JSON file to store information about selected target, run arguments and build type.
+  default_parameters = { run_dir = '', args = {}, build_type = '' }, -- The default values in `parameters_file`.
   build_dir = tostring(Path:new('{cwd}', 'build', '{os}-{build_type}')), -- Build directory. The expressions `{cwd}`, `{os}` and `{build_type}` will be expanded with the corresponding text values. Could be a function that return the path to the build directory.
   samples_path = tostring(script_path:parent():parent():parent() / 'samples'), -- Folder with samples. `samples` folder from the plugin directory is used by default.
   default_projects_path = tostring(Path:new(vim.loop.os_homedir(), 'Projects')), -- Default folder for creating project.
@@ -71,7 +72,7 @@ require('cmake').setup({
 })
 ```
 
-The mentioned `parameters_file` will be created for every project with the following content:
+The mentioned `parameters_file` will be created for every project with `default_parameters`:
 
 ```jsonc
 {

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ require('cmake').setup({
   cmake_executable = 'cmake', -- CMake executable to run.
   save_before_build = true, -- Save all buffers before building.
   parameters_file = 'neovim.json', -- JSON file to store information about selected target, run arguments and build type.
-  default_parameters = { run_dir = '', args = {}, build_type = '' }, -- The default values in `parameters_file`.
+  default_parameters = { run_dir = '', args = {}, build_type = 'Debug' }, -- The default values in `parameters_file`.
   build_dir = tostring(Path:new('{cwd}', 'build', '{os}-{build_type}')), -- Build directory. The expressions `{cwd}`, `{os}` and `{build_type}` will be expanded with the corresponding text values. Could be a function that return the path to the build directory.
   samples_path = tostring(script_path:parent():parent():parent() / 'samples'), -- Folder with samples. `samples` folder from the plugin directory is used by default.
   default_projects_path = tostring(Path:new(vim.loop.os_homedir(), 'Projects')), -- Default folder for creating project.
@@ -78,7 +78,7 @@ The mentioned `parameters_file` will be created for every project with `default_
 {
   "args": {}, // A dictionary with target names and their arguments specified as an array.
   "current_target": "", // Current target name.
-  "build_type": "", // Current build type, can be Debug, Release, RelWithDebInfo or MinSizeRel.
+  "build_type": "Debug", // Current build type, can be Debug, Release, RelWithDebInfo or MinSizeRel.
   "run_dir": "" // Default working directory for targets. By default is missing, the current target directory will be used
 }
 ```

--- a/lua/cmake/config.lua
+++ b/lua/cmake/config.lua
@@ -6,7 +6,7 @@ local config = {
     cmake_executable = 'cmake',
     save_before_build = true,
     parameters_file = 'neovim.json',
-    default_parameters = { run_dir = '', args = {}, build_type = '' },
+    default_parameters = { run_dir = '', args = {}, build_type = 'Debug' },
     build_dir = tostring(Path:new('{cwd}', 'build', '{os}-{build_type}')),
     samples_path = tostring(script_path:parent():parent():parent() / 'samples'),
     default_projects_path = tostring(Path:new(vim.loop.os_homedir(), 'Projects')),

--- a/lua/cmake/config.lua
+++ b/lua/cmake/config.lua
@@ -6,6 +6,7 @@ local config = {
     cmake_executable = 'cmake',
     save_before_build = true,
     parameters_file = 'neovim.json',
+    default_parameters = { run_dir = '', args = {}, build_type = 'Debug' },
     build_dir = tostring(Path:new('{cwd}', 'build', '{os}-{build_type}')),
     samples_path = tostring(script_path:parent():parent():parent() / 'samples'),
     default_projects_path = tostring(Path:new(vim.loop.os_homedir(), 'Projects')),

--- a/lua/cmake/config.lua
+++ b/lua/cmake/config.lua
@@ -6,7 +6,7 @@ local config = {
     cmake_executable = 'cmake',
     save_before_build = true,
     parameters_file = 'neovim.json',
-    default_parameters = { run_dir = '', args = {}, build_type = 'Debug' },
+    default_parameters = { run_dir = '', args = {}, build_type = '' },
     build_dir = tostring(Path:new('{cwd}', 'build', '{os}-{build_type}')),
     samples_path = tostring(script_path:parent():parent():parent() / 'samples'),
     default_projects_path = tostring(Path:new(vim.loop.os_homedir(), 'Projects')),

--- a/lua/cmake/project_config.lua
+++ b/lua/cmake/project_config.lua
@@ -6,11 +6,6 @@ local Path = require('plenary.path')
 local ProjectConfig = {}
 ProjectConfig.__index = ProjectConfig
 
-local json_defaults = {
-  args = {},
-  build_type = 'Debug',
-}
-
 function ProjectConfig.new()
   local project_config = {}
   local parameters_file = Path:new(config.parameters_file)
@@ -19,7 +14,7 @@ function ProjectConfig.new()
   else
     project_config.json = {}
   end
-  project_config.json = vim.tbl_extend('keep', project_config.json, json_defaults)
+  project_config.json = vim.tbl_extend('keep', project_config.json, config.default_parameters)
   return setmetatable(project_config, ProjectConfig)
 end
 


### PR DESCRIPTION
Hi!
The default json file makes user run program in target's parent path which usually isn't cwd (when run_dir is nil).
Some people, like me, would perfer running program from cwd.
So I make a commit that allow user to change "default parameters" of that json file. 
What do you think?