### PR TITLE
Add support for select target callback

### DIFF
--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -164,7 +164,7 @@ function cmake.select_build_type()
   end)
 end
 
-function cmake.select_target(callback)
+function cmake.select_target(callback, ...)
   local project_config = ProjectConfig.new()
   if not project_config:get_build_dir():is_dir() then
     utils.notify('You need to configure first', vim.log.levels.ERROR)
@@ -188,15 +188,15 @@ function cmake.select_target(callback)
     end
   end
 
+  local args = ...
   vim.ui.select(display_targets, { prompt = 'Select target' }, function(_, idx)
     if not idx then
       return
     end
     project_config.json.current_target = targets[idx]
     project_config:write()
-
     if callback ~= nil and type(callback) == 'function' then
-        callback()
+        callback(args)
     end
   end)
 end

--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -196,10 +196,10 @@ function cmake.select_target(cb, ...)
     project_config.json.current_target = targets[idx]
     project_config:write()
     if cb ~= nil then
-        local t = type(cb)
-        if t == 'function' or (t == 'table' and type(getmetatable(cb).__call) == 'function') then
-            cb(args)
-        end
+      local t = type(cb)
+      if t == 'function' or (t == 'table' and type(getmetatable(cb).__call) == 'function') then
+        cb(args)
+      end
     end
   end)
 end

--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -164,7 +164,7 @@ function cmake.select_build_type()
   end)
 end
 
-function cmake.select_target()
+function cmake.select_target(callback)
   local project_config = ProjectConfig.new()
   if not project_config:get_build_dir():is_dir() then
     utils.notify('You need to configure first', vim.log.levels.ERROR)
@@ -194,6 +194,10 @@ function cmake.select_target()
     end
     project_config.json.current_target = targets[idx]
     project_config:write()
+
+    if callback ~= nil and type(callback) == 'function' then
+        callback()
+    end
   end)
 end
 

--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -164,7 +164,7 @@ function cmake.select_build_type()
   end)
 end
 
-function cmake.select_target(callback, ...)
+function cmake.select_target(cb, ...)
   local project_config = ProjectConfig.new()
   if not project_config:get_build_dir():is_dir() then
     utils.notify('You need to configure first', vim.log.levels.ERROR)
@@ -195,8 +195,11 @@ function cmake.select_target(callback, ...)
     end
     project_config.json.current_target = targets[idx]
     project_config:write()
-    if callback ~= nil and type(callback) == 'function' then
-        callback(args)
+    if cb ~= nil then
+        local t = type(cb)
+        if t == 'function' or (t == 'table' and type(getmetatable(cb).__call) == 'function') then
+            cb(args)
+        end
     end
   end)
 end


### PR DESCRIPTION
Although `select_target` does not return a `plenary job`, but it use `vim.ui.select` which can use callback on confirm.
These commits add a after callback for that, so you can do something like `select target and build`