### PR TITLE
Setting and command for multiple DAP Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Use the command `:CMake` with one of the following arguments:
 | `clear_cache`          | Remove `CMakeCache.txt` file from the build directory.                                                                                                                                                                                      |
 | `open_build_dir`       | Open current build folder via `xdg-open` (Linux) or `start` (Windows).                                                                                                                                                                      |
 | `select_build_type`    | Select build type (Release, Debug, etc.).                                                                                                                                                                                                   |
+| `select_dap_config`    | Select a project sepecific DAP configuration. You can configure the options in `require('cmake').setup({ dap_configurations = { ... } })`                                                                                                   |
 | `select_target`        | Select target for running / debugging.                                                                                                                                                                                                      |
 | `create_project`       | Create new CMake project.                                                                                                                                                                                                                   |
 | `cancel`               | Cancel current running CMake action like `build` or `run`.                                                                                                                                                                                  |
@@ -67,7 +68,11 @@ require('cmake').setup({
     only_on_error = false, -- Open quickfix window only if target build failed.
   },
   copy_compile_commands = true, -- Copy compile_commands.json to current working directory.
-  dap_configuration = { type = 'lldb', request = 'launch' }, -- DAP configuration. By default configured to work with `lldb-vscode`.
+  dap_configurations = { -- Table of different DAP configurations.
+    lldb_vscode = { type = 'lldb', request = 'launch' },
+    cppdbg_vscode = { type = 'cppdbg', request = 'launch' },
+  },
+  dap_configuration = 'lldb_vscode', -- DAP configuration to use if the projects `parameters_file` does not specify one.
   dap_open_command = require('dap').repl.open, -- Command to run after starting DAP session. You can set it to `false` if you don't want to open anything or `require('dapui').open` if you are using https://github.com/rcarriga/nvim-dap-ui
 })
 ```
@@ -82,6 +87,8 @@ The mentioned `parameters_file` will be created for every project with `default_
   "run_dir": "" // Default working directory for targets. By default is missing, the current target directory will be used
 }
 ```
+
+Project specific DAP configuration (ex. `"dap_configuration": "cppdbg"`) will also be contained here but is left out if the project uses the global default.
 
 Usually you don't need to edit it manually, you can set its values using the `:CMake <subcommand>` commands.
 

--- a/README.md
+++ b/README.md
@@ -84,11 +84,10 @@ The mentioned `parameters_file` will be created for every project using `default
   "args": {"target_name": ["arg1", "arg2"]}, // A dictionary with target names and their arguments specified as an array.
   "current_target": "target_name", // Current target name.
   "build_type": "Debug", // Current build type, can be Debug, Release, RelWithDebInfo or MinSizeRel.
-  "run_dir": "build/my_folder" // Default working directory for targets. Can be absolute or relative to the current Neovim working directory. By default is missing, in this case current target directory will be used.
+  "run_dir": "build/my_folder", // Default working directory for targets. Can be absolute or relative to the current Neovim working directory. By default is missing, in this case current target directory will be used.
+  "dap_configuration": "cppdbg_vscode" // A string specifying a specific dap configuration to use for this project. If absent then the `dap_configuration` from `require('cmake').setup` will be used, which is the default behaviour.
 }
 ```
-
-Project specific DAP configuration (ex. `"dap_configuration": "cppdbg"`) will also be contained here but is left out if the project uses the global default.
 
 Usually you don't need to edit it manually, you can set its values using the `:CMake <subcommand>` commands.
 

--- a/lua/cmake/config.lua
+++ b/lua/cmake/config.lua
@@ -19,7 +19,11 @@ local config = {
       only_on_error = false,
     },
     copy_compile_commands = true,
-    dap_configuration = { type = 'lldb', request = 'launch' },
+    dap_configurations = {
+      lldb_vscode = { type = 'lldb', request = 'launch' },
+      cppdbg_vscode = { type = 'cppdbg', request = 'launch', cwd = '${workspaceFolder}' },
+    },
+    dap_configuration = 'lldb_vscode',
     dap_open_command = require('dap').repl.open,
   },
 }

--- a/lua/cmake/config.lua
+++ b/lua/cmake/config.lua
@@ -21,7 +21,7 @@ local config = {
     copy_compile_commands = true,
     dap_configurations = {
       lldb_vscode = { type = 'lldb', request = 'launch' },
-      cppdbg_vscode = { type = 'cppdbg', request = 'launch', cwd = '${workspaceFolder}' },
+      cppdbg_vscode = { type = 'cppdbg', request = 'launch' },
     },
     dap_configuration = 'lldb_vscode',
     dap_open_command = require('dap').repl.open,

--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -64,9 +64,7 @@ function cmake.debug(...)
   local dap_config = project_config.json.dap_configuration or config.dap_configuration
   if type(dap_config) == 'string' then
     if not config.dap_configurations[dap_config] then
-      utils.notify(
-        string.format("`%s` not found in cmakes `dap_configurations` settings", dap_config),
-        vim.log.levels.ERROR)
+      utils.notify(string.format('`%s` not found in cmakes `dap_configurations` settings', dap_config), vim.log.levels.ERROR)
       return
     end
 
@@ -180,9 +178,9 @@ end
 function cmake.select_dap_config()
   local project_config = ProjectConfig.new()
   local dap_configs = vim.tbl_keys(config.dap_configurations)
-  table.insert(dap_configs, "Use default")
+  table.insert(dap_configs, 'Use default')
 
-  vim.ui.select(dap_configs, { prompt = "Select DAP Configuration" }, function (choice, idx)
+  vim.ui.select(dap_configs, { prompt = 'Select DAP Configuration' }, function (choice, idx)
     if not idx then
       return
     end

--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -180,7 +180,7 @@ function cmake.select_dap_config()
   local dap_configs = vim.tbl_keys(config.dap_configurations)
   table.insert(dap_configs, 'Use default')
 
-  vim.ui.select(dap_configs, { prompt = 'Select DAP Configuration' }, function (choice, idx)
+  vim.ui.select(dap_configs, { prompt = 'Select DAP Configuration' }, function(choice, idx)
     if not idx then
       return
     end

--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -179,18 +179,14 @@ end
 
 function cmake.select_dap_config()
   local project_config = ProjectConfig.new()
-  local dap_configs = {}
-  local n = 1
-  for k, _ in pairs(config.dap_configurations) do
-    dap_configs[n] = k
-    n = n + 1
-  end
-  dap_configs[n] = "Use default"
+  local dap_configs = vim.tbl_keys(config.dap_configurations)
+  table.insert(dap_configs, "Use default")
+
   vim.ui.select(dap_configs, { prompt = "Select DAP Configuration" }, function (choice, idx)
     if not idx then
       return
     end
-    project_config.json.dap_configuration = idx ~= n and choice or nil
+    project_config.json.dap_configuration = idx ~= #dap_configs and choice or nil
     project_config:write()
   end)
 end


### PR DESCRIPTION
Adds the option to specify multiple dap configurations during setup and
a command `select_dap_config` which prompts the user to pick a
configuration to be used for the current project.

The choice is also stored in the ProjectConfiguration json file.

While it changes the `dap_configuration` setting from a table to a string
in the defaults it is still backwards compatible with the old style.

I e you can still specify a single table with configurations if you don't want
to use the new `dap_configurations` setting.