### PR TITLE
Make dap optional during loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Neovim CMake
 
-A Neovim 0.7+ plugin that use [cmake-file-api](https://cmake.org/cmake/help/latest/manual/cmake-file-api.7.html#codemodel-version-2) to provide integration with building, running and debugging projects with output to quickfix.
+A Neovim 0.7+ plugin that uses [cmake-file-api](https://cmake.org/cmake/help/latest/manual/cmake-file-api.7.html#codemodel-version-2) to provide integration with building, running and debugging projects with output to quickfix.
 
 ## Dependencies
 
-- [cmake](https://cmake.org) for building and reading project information.
-- [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) for internal helpers.
-- [nvim-dap](https://github.com/mfussenegger/nvim-dap) for debugging.
+- Necessary
+  - [cmake](https://cmake.org) for building and reading project information.
+  - [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) for internal helpers.
+- Optional
+  - [nvim-dap](https://github.com/mfussenegger/nvim-dap) - for debugging.
 
 ## Commands
 
@@ -73,7 +75,7 @@ require('cmake').setup({
     cppdbg_vscode = { type = 'cppdbg', request = 'launch' },
   },
   dap_configuration = 'lldb_vscode', -- DAP configuration to use if the projects `parameters_file` does not specify one.
-  dap_open_command = require('dap').repl.open, -- Command to run after starting DAP session. You can set it to `false` if you don't want to open anything or `require('dapui').open` if you are using https://github.com/rcarriga/nvim-dap-ui
+  dap_open_command = function(...) require('dap').repl.open(...) end, -- Command to run after starting DAP session. You can set it to `false` if you don't want to open anything or `require('dapui').open` if you are using https://github.com/rcarriga/nvim-dap-ui
 })
 ```
 

--- a/lua/cmake/config.lua
+++ b/lua/cmake/config.lua
@@ -24,7 +24,7 @@ local config = {
       cppdbg_vscode = { type = 'cppdbg', request = 'launch' },
     },
     dap_configuration = 'lldb_vscode',
-    dap_open_command = require('dap').repl.open,
+    dap_open_command = function(...) return require('dap').repl.open(...) end,
   },
 }
 

--- a/lua/cmake/init.lua
+++ b/lua/cmake/init.lua
@@ -1,4 +1,3 @@
-local dap = require('dap')
 local utils = require('cmake.utils')
 local config = require('cmake.config')
 local scandir = require('plenary.scandir')
@@ -85,7 +84,7 @@ function cmake.debug(...)
     cwd = target_dir.filename,
   }
 
-  dap.run(vim.tbl_extend('force', base_dap_config, dap_config))
+  require('dap').run(vim.tbl_extend('force', base_dap_config, dap_config))
   vim.api.nvim_command('cclose')
   if config.dap_open_command then
     config.dap_open_command()


### PR DESCRIPTION
Make lazy loading easier, by only requiring dap when debugging.